### PR TITLE
Style: Adjust modal width for better responsive centering

### DIFF
--- a/css/design/global.css
+++ b/css/design/global.css
@@ -11,7 +11,7 @@
   --clr-tx-dark: #f0f0f0;
 
   --overlay-bg: rgba(0, 0, 0, 0.6);
-  --modal-width: 90%;
+  --modal-width: 80%;
   --modal-max-width: 600px;
 
   --spacing-sm: 0.5rem;


### PR DESCRIPTION
I'll set the modal width to 80% of the viewport width to ensure it's well-sized on smaller screens, while retaining a max-width of 600px for larger displays. The existing centering mechanism will ensure it remains centered on all screen sizes.