### PR TITLE
Style: Add specific rules to ensure all modals use 80% width

### DIFF
--- a/css/design/global.css
+++ b/css/design/global.css
@@ -11,7 +11,7 @@
   --clr-tx-dark: #f0f0f0;
 
   --overlay-bg: rgba(0, 0, 0, 0.6);
-  --modal-width: 90%;
+  --modal-width: 80%;
   --modal-max-width: 600px;
 
   --spacing-sm: 0.5rem;
@@ -166,6 +166,13 @@ button {
   transform: translate(-50%, -50%);
   z-index: 1001;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+
+/* Ensure specific modals also adhere to the modal width - for robustness */
+#modal-cc,
+#modal-it,
+#modal-pro {
+  width: var(--modal-width);
 }
 
 .modal-close {


### PR DESCRIPTION
Added ID-specific CSS rules for #modal-cc, #modal-it, and #modal-pro to explicitly set their width using the --modal-width variable (80%).

This is to ensure consistent sizing across all modals, addressing an issue where some modals were not adopting the intended width despite the general .modal class styling.