### PR TITLE
Delay component init until HTML fragments load

### DIFF
--- a/contact/contact.js
+++ b/contact/contact.js
@@ -1,21 +1,12 @@
 // contact/contact.js
-document.addEventListener('DOMContentLoaded', () => {
+function initContactForm() {
   const form = document.getElementById('contactForm');
   const modal = document.getElementById('contactModal'); // Still needed to close it after submit
-
-  // Modal open/close listeners (for trigger buttons, ESC, overlay clicks, close buttons)
-  // are now handled by the generic modal system in js/funct/index.js.
-  // [data-modal="contactModal"] buttons will open this modal.
-  // [data-close] inside this modal will close it.
-  // Clicking on the modal overlay (contactModal itself) will close it.
-  // ESC key will close it.
 
   if (form && modal) {
     form.addEventListener('submit', (e) => {
       e.preventDefault();
       alert('Contact form submitted!'); // Or actual form submission logic
-      // Close the modal after submission using the global closeModal or by directly manipulating class
-      // Assuming 'contactModal' is a componentModalOverlayId in js/funct/index.js
       if (typeof closeModal === 'function') {
         closeModal('contactModal');
       } else {
@@ -23,4 +14,12 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
-});
+}
+
+const contactContainer = document.querySelector('div[include-html="contact/contact.html"]');
+if (contactContainer) {
+  contactContainer.addEventListener('html-included', initContactForm);
+  if (contactContainer.innerHTML.trim() !== '') {
+    initContactForm();
+  }
+}

--- a/expand-nav/nav.js
+++ b/expand-nav/nav.js
@@ -1,21 +1,16 @@
 // expand-nav/nav.js
-document.addEventListener('DOMContentLoaded', () => {
+function initMobileNav() {
   const nav = document.getElementById('mobileNav');
-  const menuToggle = document.getElementById('menuToggle'); // This is the FAB button in index.html
+  const menuToggle = document.getElementById('menuToggle');
   const servicesToggle = document.getElementById('mobile-services-toggle');
   const servicesMenu = document.getElementById('mobile-services-menu');
-  // const langBtn = document.getElementById('mobile-language-toggle'); // Logic moved to js/funct/index.js
-  // const themeBtn = document.getElementById('mobile-theme-toggle'); // Logic moved to js/funct/index.js
 
-  // Show/hide horizontal nav (mobileNav)
-  // This is triggered by the FAB #menuToggle button from index.html
-  if (menuToggle && nav) { // Ensure both elements exist
+  if (menuToggle && nav) {
     menuToggle.addEventListener('click', () => {
       nav.classList.toggle('active');
     });
   }
 
-  // Show/hide services menu
   if (servicesToggle && servicesMenu) {
     servicesToggle.addEventListener('click', () => {
       const isActive = servicesMenu.classList.toggle('active');
@@ -23,8 +18,14 @@ document.addEventListener('DOMContentLoaded', () => {
       servicesMenu.setAttribute('aria-hidden', !isActive);
     });
   }
+}
 
-  // Language and Theme toggle logic has been moved to js/funct/index.js
-  // That script will attach event listeners to 'mobile-language-toggle' and 'mobile-theme-toggle'
-  // and will also update their text content.
-});
+const navContainer = document.querySelector('div[include-html="expand-nav/nav.html"]');
+if (navContainer) {
+  navContainer.addEventListener('html-included', initMobileNav);
+  if (navContainer.innerHTML.trim() !== '') {
+    initMobileNav();
+  }
+}
+
+// Language and Theme toggle logic has been moved to js/funct/index.js

--- a/index.html
+++ b/index.html
@@ -73,7 +73,10 @@
     document.querySelectorAll('[include-html]').forEach(el => {
       fetch(el.getAttribute('include-html'))
         .then(res => res.text())
-        .then(html => { el.innerHTML = html; el.dispatchEvent(new Event('html-included')) });
+        .then(html => {
+          el.innerHTML = html;
+          el.dispatchEvent(new CustomEvent('html-included', { bubbles: true }));
+        });
     });
   </script>
 

--- a/join/join.js
+++ b/join/join.js
@@ -1,16 +1,12 @@
 // join/join.js
-document.addEventListener('DOMContentLoaded', () => {
+function initJoinForm() {
   const form = document.getElementById('joinForm');
   const modal = document.getElementById('joinModal'); // Still needed to close it after submit
-
-  // Modal open/close listeners (for trigger buttons, ESC, overlay clicks, close buttons)
-  // are now handled by the generic modal system in js/funct/index.js.
 
   if (form && modal) {
     form.addEventListener('submit', (e) => {
       e.preventDefault();
       alert('Join Us form submitted!'); // Or actual form submission logic
-      // Close the modal after submission
       if (typeof closeModal === 'function') {
         closeModal('joinModal');
       } else {
@@ -18,4 +14,12 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
-});
+}
+
+const joinContainer = document.querySelector('div[include-html="join/join.html"]');
+if (joinContainer) {
+  joinContainer.addEventListener('html-included', initJoinForm);
+  if (joinContainer.innerHTML.trim() !== '') {
+    initJoinForm();
+  }
+}

--- a/mychatbot/chatbot.js
+++ b/mychatbot/chatbot.js
@@ -1,6 +1,5 @@
 // mychatbot/chatbot.js
-document.addEventListener('DOMContentLoaded', () => {
-  // const modal = document.getElementById('chatbotModal'); // Modal element itself
+function initChatbot() {
   const input = document.getElementById('chatbot-input');
   const form = document.getElementById('chatbot-input-row');
   const log = document.getElementById('chat-log');
@@ -63,4 +62,12 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
-});
+}
+
+const chatbotContainer = document.querySelector('div[include-html="mychatbot/chatbot.html"]');
+if (chatbotContainer) {
+  chatbotContainer.addEventListener('html-included', initChatbot);
+  if (chatbotContainer.innerHTML.trim() !== '') {
+    initChatbot();
+  }
+}


### PR DESCRIPTION
## Summary
- fire a bubbling `html-included` event when inserting HTML fragments
- initialize Join, Contact, Nav and Chatbot components once their fragments are loaded

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68708b782628832ba98586611fcdadb4