### PR TITLE
Add service modal HTMLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,10 @@
 
   <!-- 📦 SERVICE MODALS -->
   <div id="modal-overlay" class="overlay hidden"></div>
-  <!-- (Insert modal-ops, modal-cc, modal-it, modal-pro here — already included above from your source) -->
+  <div include-html="services/modal-ops.html"></div>
+  <div include-html="services/modal-cc.html"></div>
+  <div include-html="services/modal-it.html"></div>
+  <div include-html="services/modal-pro.html"></div>
 
   <!-- 🧾 FOOTER -->
   <footer class="site-footer">

--- a/services/modal-cc.html
+++ b/services/modal-cc.html
@@ -1,0 +1,10 @@
+<!-- services/modal-cc.html -->
+<div id="modal-cc" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="ccTitle">
+  <div class="modal-header">
+    <h2 id="ccTitle" data-en="Contact Center" data-es="Centro de Servicios">Contact Center</h2>
+    <button class="close-modal" data-close>&times;</button>
+  </div>
+  <div class="modal-body">
+    <p data-en="Learn about our contact center solutions." data-es="Conozca nuestras soluciones de centro de servicios.">Learn about our contact center solutions.</p>
+  </div>
+</div>

--- a/services/modal-it.html
+++ b/services/modal-it.html
@@ -1,0 +1,10 @@
+<!-- services/modal-it.html -->
+<div id="modal-it" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="itTitle">
+  <div class="modal-header">
+    <h2 id="itTitle" data-en="IT Support" data-es="Soporte IT">IT Support</h2>
+    <button class="close-modal" data-close>&times;</button>
+  </div>
+  <div class="modal-body">
+    <p data-en="Get help with reliable and secure IT services." data-es="Obtenga ayuda con servicios de TI confiables y seguros.">Get help with reliable and secure IT services.</p>
+  </div>
+</div>

--- a/services/modal-ops.html
+++ b/services/modal-ops.html
@@ -1,0 +1,10 @@
+<!-- services/modal-ops.html -->
+<div id="modal-ops" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="opsTitle">
+  <div class="modal-header">
+    <h2 id="opsTitle" data-en="Business Operations" data-es="Gestión">Business Operations</h2>
+    <button class="close-modal" data-close>&times;</button>
+  </div>
+  <div class="modal-body">
+    <p data-en="Information about our business operations services." data-es="Información sobre nuestros servicios de gestión de negocios.">Information about our business operations services.</p>
+  </div>
+</div>

--- a/services/modal-pro.html
+++ b/services/modal-pro.html
@@ -1,0 +1,10 @@
+<!-- services/modal-pro.html -->
+<div id="modal-pro" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="proTitle">
+  <div class="modal-header">
+    <h2 id="proTitle" data-en="Professionals" data-es="Profesionales">Professionals</h2>
+    <button class="close-modal" data-close>&times;</button>
+  </div>
+  <div class="modal-body">
+    <p data-en="Connect with our network of vetted professionals." data-es="Conéctese con nuestra red de profesionales verificados.">Connect with our network of vetted professionals.</p>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add business operations, contact center, IT support and professional service modal snippets
- embed the new service modals in `index.html`

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68714baaec5c832b976c3b073d6a7f4e