### PR TITLE
Document chatbot backend config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Neo Screen
+
+This repository hosts the static files for the OPS Online Support demo site.
+
+## Configuring the Chatbot Backend
+
+The chatbot script (`mychatbot/chatbot.js`) uses a configurable URL for its backend API. By default, the script points to `https://example.com/api/chat`. To use a different backend, define `window.CHATBOT_API_URL` before including `mychatbot/chatbot.js`.
+
+```html
+<script>
+  // Example: set the chatbot backend URL
+  window.CHATBOT_API_URL = 'https://your-domain.com/chat';
+</script>
+<script defer src="mychatbot/chatbot.js"></script>
+```
+
+Deployments can also modify the `CHATBOT_API_URL` constant directly in `mychatbot/chatbot.js` if embedding the variable is not an option.

--- a/mychatbot/chatbot.js
+++ b/mychatbot/chatbot.js
@@ -1,4 +1,7 @@
 // mychatbot/chatbot.js
+// Set the backend URL for the chatbot. Deployments can override this value by
+// defining `window.CHATBOT_API_URL` before this script loads.
+const CHATBOT_API_URL = window.CHATBOT_API_URL || 'https://example.com/api/chat';
 function initChatbot() {
   const input = document.getElementById('chatbot-input');
   const form = document.getElementById('chatbot-input-row');
@@ -37,8 +40,7 @@ function initChatbot() {
       addMsg('…', 'bot'); // Bot thinking indicator
 
       try {
-        // This URL is a placeholder and will not work without a real backend.
-        const response = await fetch('https://your-cloudflare-worker.example.com/chat', {
+        const response = await fetch(CHATBOT_API_URL, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ message: msg })


### PR DESCRIPTION
## Summary
- add configurable constant `CHATBOT_API_URL` in `chatbot.js`
- document how to configure the chatbot backend in a new `README.md`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687153464f60832b91eb5e6055277143