### PR TITLE
Add privacy banner component

### DIFF
--- a/banner/banner.css
+++ b/banner/banner.css
@@ -1,0 +1,36 @@
+/* banner/banner.css */
+.policy-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background: var(--clr-bg);
+  color: var(--clr-tx);
+  padding: var(--spacing-sm) var(--spacing-md);
+  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: var(--spacing-sm);
+  z-index: 3000;
+  font-size: 0.875rem;
+}
+
+.policy-banner a {
+  color: var(--clr-accent);
+  text-decoration: underline;
+}
+
+.policy-banner button {
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1rem;
+  cursor: pointer;
+  margin-left: var(--spacing-sm);
+}
+
+.policy-banner.hidden {
+  display: none;
+}

--- a/banner/banner.html
+++ b/banner/banner.html
@@ -1,0 +1,8 @@
+<!-- banner/banner.html -->
+<div id="policyBanner" class="policy-banner">
+  <span data-en="By using this site, you agree to our" data-es="Al usar este sitio, acepta nuestra"></span>
+  <a href="privacy.html" data-en="Privacy Policy" data-es="Política de Privacidad">Privacy Policy</a>
+  <span data-en="and" data-es="y">and</span>
+  <a href="cookies.html" data-en="Cookie Policy" data-es="Política de Cookies">Cookie Policy</a>.
+  <button id="policyBannerClose" aria-label="Close">&times;</button>
+</div>

--- a/banner/banner.js
+++ b/banner/banner.js
@@ -1,0 +1,32 @@
+// banner/banner.js
+function initPolicyBanner() {
+  const banner = document.getElementById('policyBanner');
+  const closeBtn = document.getElementById('policyBannerClose');
+
+  if (!banner) return;
+
+  if (localStorage.getItem('policyBannerClosed') === '1') {
+    banner.classList.add('hidden');
+  }
+
+  if (closeBtn) {
+    closeBtn.addEventListener('click', () => {
+      banner.classList.add('hidden');
+      localStorage.setItem('policyBannerClosed', '1');
+    });
+  }
+
+  // Apply current language to newly added elements if applyLanguage exists
+  if (typeof applyLanguage === 'function') {
+    const currentLang = document.body.getAttribute('data-lang') || 'en';
+    applyLanguage(currentLang, false);
+  }
+}
+
+const bannerContainer = document.querySelector('div[include-html="banner/banner.html"]');
+if (bannerContainer) {
+  bannerContainer.addEventListener('html-included', initPolicyBanner);
+  if (bannerContainer.innerHTML.trim() !== '') {
+    initPolicyBanner();
+  }
+}

--- a/cookies.html
+++ b/cookies.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cookie Policy</title>
+  <link rel="stylesheet" href="css/design/global.css" />
+</head>
+<body class="theme-dark" data-lang="en">
+  <main style="padding: var(--spacing-md);">
+    <h1 data-en="Cookie Policy" data-es="Política de Cookies">Cookie Policy</h1>
+    <p data-en="This is a placeholder cookie policy." data-es="Esta es una política de cookies de ejemplo.">This is a placeholder cookie policy.</p>
+  </main>
+  <script defer src="js/funct/index.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   <link rel="stylesheet" href="contact/contact.css" />
   <link rel="stylesheet" href="mychatbot/chatbot.css" />
   <link rel="stylesheet" href="expand-nav/nav.css" />
+  <link rel="stylesheet" href="banner/banner.css" />
 </head>
 <body class="theme-dark" data-lang="en">
   <!-- 🔰 HEADER -->
@@ -70,6 +71,8 @@
   <footer class="site-footer">
     <p>© 2025 <span data-en="OPS Online Support" data-es="OPS Soporte en Línea">OPS Online Support</span></p>
   </footer>
+
+  <div include-html="banner/banner.html"></div>
 
   <!-- 🔁 HTML Loader -->
   <script>
@@ -129,6 +132,7 @@
   <script defer src="contact/contact.js"></script>
   <script defer src="mychatbot/chatbot.js"></script>
   <script defer src="expand-nav/nav.js"></script>
+  <script defer src="banner/banner.js"></script>
   <script defer src="js/funct/index.js"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Privacy Policy</title>
+  <link rel="stylesheet" href="css/design/global.css" />
+</head>
+<body class="theme-dark" data-lang="en">
+  <main style="padding: var(--spacing-md);">
+    <h1 data-en="Privacy Policy" data-es="Política de Privacidad">Privacy Policy</h1>
+    <p data-en="This is a placeholder privacy policy." data-es="Esta es una política de privacidad de ejemplo.">This is a placeholder privacy policy.</p>
+  </main>
+  <script defer src="js/funct/index.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add cookie/privacy banner component with translations
- link policy pages for banner
- load banner resources in index.html
- provide placeholder privacy and cookie policy pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68724b810298832b8242bf4daaa66e29