### PR TITLE
Limit service-worker offline fallback to navigations

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -34,7 +34,12 @@ self.addEventListener('fetch', event => {
       if (cached) {
         return cached;
       }
-      return fetch(event.request).catch(() => caches.match(OFFLINE_URL));
+      return fetch(event.request).catch(err => {
+        if (event.request.mode === 'navigate') {
+          return caches.match(OFFLINE_URL);
+        }
+        return Promise.reject(err);
+      });
     })
   );
 });


### PR DESCRIPTION
## Summary
- only use offline fallback for navigation requests

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6872ee86b2d8832b9e905bcce432c758